### PR TITLE
Update list of supported SSH keys in SFTP readme

### DIFF
--- a/settlements/sftp-report-service/README.md
+++ b/settlements/sftp-report-service/README.md
@@ -21,7 +21,7 @@ More information about SFTP: [SSH File Transfer Protocol](https://en.wikipedia.o
 
 ![Lag tilgang](images/02_SFTP_tilgang.png "Lag tilgang")
 
-3. In the next window you can add the public keys of the user(s). We support RSA, EdDSA and Ed25519 keys in OpenSSH format (and reject DSA keys). After this you should see the newly created user. For help creating SSH keys, the GitHub documentation may be helpful: https://help.github.com/articles/connecting-to-github-with-ssh/
+3. In the next window you can add the public keys of the user(s). We support RSA (minimum 2048-bit), EdDSA and Ed25519 keys in OpenSSH format (and reject DSA keys). After this you should see the newly created user. For help creating SSH keys, the GitHub documentation may be helpful: https://help.github.com/articles/connecting-to-github-with-ssh/
 
 ![Bruker opprettet](images/03_bruker_opprettet.png "bruker opprettet")
 


### PR DESCRIPTION
We plan to remove support for 1024-bit RSA keys in the SFTP Report Service this week, so the readme should be updated to reflect this.