### PR TITLE
Fix typo in ecom example code callback handler

### DIFF
--- a/code-examples/ecom_python_example/app.py
+++ b/code-examples/ecom_python_example/app.py
@@ -89,7 +89,7 @@ def callback_route(order_id):
     """
     callback_msg = request.get_json()
     log_callback(__name__ + ".callback_route", callback_msg=callback_msg, path_var=order_id)
-    if callback_msg["transactionInfo"]["status"] == "RESERVE":
+    if callback_msg["transactionInfo"]["status"] == "RESERVED":
         access_token = token_request()["access_token"]
         capture_payment(order_id, access_token)
     return ""


### PR DESCRIPTION
In the ecom Python example, the callback function currently fails to automatically capture reserved payments. The function in question:

https://github.com/vippsas/vipps-developers/blob/2985f2f2160eaf16a4e54cfd8eddc27613841167/code-examples/ecom_python_example/app.py#L82-L95


The reason is line 92, when checking if the status shows the payment as reserved.

https://github.com/vippsas/vipps-developers/blob/2985f2f2160eaf16a4e54cfd8eddc27613841167/code-examples/ecom_python_example/app.py#L92

The actual status string set on reserved payments is `RESERVED`, not `RESERVE`, and so the condition is never satisfied. The PR involves fixing the typo.

Although this literally is the smallest possible PR, this took a while to actually spot and caused a good bit of frustration. So for the next person trying out the example, this will make their day a little brighter. 