### PR TITLE
Set links for vipps landing page back to ecom, where it is most used

### DIFF
--- a/common-topics/README.md
+++ b/common-topics/README.md
@@ -28,4 +28,3 @@ These are topics that are applicable across many APIs:
 * [TransactionText](transactiontext.md)
 * [URL validation](url-validation.md)
 * [User Info](userinfo.md)
-* [Vipps landing page](vipps-landing-page.md)

--- a/common-topics/isApp.md
+++ b/common-topics/isApp.md
@@ -52,7 +52,7 @@ The effect of the above is the same in all normal cases.
 
 * The merchant's native app must be sure that the user's phone can open the
   `vipps://` deeplink, as the
-  [Vipps landing page](vipps-landing-page.md)
+  [Vipps landing page](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#the-vipps-landing-page)
   will not be shown to the user, and it will therefore not be possible to
   enter a phone number and pay with Vipps on another device.
 * Vipps requires a minimum version of the phone's operating system. At the time

--- a/faqs/vipps-landing-page-faq.md
+++ b/faqs/vipps-landing-page-faq.md
@@ -40,7 +40,7 @@ where there is no display available.
 The Vipps landing page is more than just a web page, it is an entire
 application and it plays an important role in the Vipps payment process.
 See
-[The Vipps landing page](../common-topics/vipps-landing-page.md)
+[The Vipps landing page](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#the-vipps-landing-page)
 for more information
 
 If you need to skip the landing page in a Point of Sale (POS) solution, see:
@@ -56,7 +56,7 @@ click the email link under the "i" information bubble.
 Include a detailed description of why it is not possible to display the landing page.
 
 See:
-[Skip landing page](../common-topics/vipps-landing-page.md#skip-landing-page).
+[Skip landing page](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#the-vipps-landing-page#skip-landing-page).
 
 ## How can I check if I have skipLandingPage activated?
 
@@ -86,7 +86,7 @@ If you do not get an error, it's active.
 If you get an error, it's not active.
 
 See:
-[Skip landing page](../common-topics/vipps-landing-page.md#skip-landing-page).
+[Skip landing page](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#the-vipps-landing-page#skip-landing-page).
 
 ## Can I show the landing page in an iframe?
 
@@ -96,4 +96,4 @@ and result in a lower success rate. In general: Any "optimization" of the paymen
 flow may break the Vipps payment flow - if not today, then later.
 
 See:
-[Skip landing page](../common-topics/vipps-landing-page.md#skip-landing-page).
+[Skip landing page](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#the-vipps-landing-page#skip-landing-page).

--- a/newsletters/2020-04-newsletter.md
+++ b/newsletters/2020-04-newsletter.md
@@ -34,7 +34,7 @@ If there is no way to show the Vipps landing page, it can be skipped.
 
 This may be useful for POS integration, vending machines, etc.
 See
-[Skip landing page](../common-topics/vipps-landing-page.md#skip-landing-page)
+[Skip landing page](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#the-vipps-landing-page#skip-landing-page)
 for details.
 
 ## eCom: Cancel pending payments

--- a/newsletters/2022-01-newsletter.md
+++ b/newsletters/2022-01-newsletter.md
@@ -46,7 +46,7 @@ One example: Far too many calls to
 [`POST:/ecomm/v2/payments`](https://vippsas.github.io/vipps-developer-docs/api/ecom#tag/Vipps-eCom-API/operation/initiatePaymentV3UsingPOST)
 use an incorrectly formatted phone number.
 The effect is that the user's phone number is not correctly pre-filled on
-the [Vipps landing page](../common-topics/vipps-landing-page.md).
+the [Vipps landing page](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#the-vipps-landing-page).
 
 Please make sure you send the `mobileNumber` in `91234567` format, not
 `+47 91 23 45 67` or something else.

--- a/newsletters/2022-11-newsletter.md
+++ b/newsletters/2022-11-newsletter.md
@@ -86,7 +86,7 @@ Far too many Vipps payments fail because of badly formatted phone numbers.
 We try to silently correct them, but can not fix all errors.
 
 This is especially important when using
-[Skip landing page](../common-topics/vipps-landing-page.md#skip-landing-page),
+[Skip landing page](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#the-vipps-landing-page#skip-landing-page),
 as it's impossible to send a push message to a user if the specified phone number is incorrect.
 
 Please see the API specification:


### PR DESCRIPTION
This is just keeping these changes in case I need to use them. I'm not sure how to handle the vipps landing page, for now.