### PR TITLE
Link to common contact page, some text tweaks

### DIFF
--- a/about.md
+++ b/about.md
@@ -32,5 +32,5 @@ Most MobilePay developer information is still found on the
 [MobilePay developers website](https://developer.mobilepay.dk/),
 but will be moved to this website soon.
 
-If you need help using the Vipps MobilePay APIs or other technical developer help:
+If you need help using the Vipps MobilePay APIs or other technical development:
 [Contact us](contact.md).

--- a/about.md
+++ b/about.md
@@ -17,17 +17,20 @@ END_METADATA -->
 
 <!-- END_COMMENT -->
 
-Vipps and MobilePay have recently merged and the documentation is currently being updated.
+Vipps and MobilePay merged in November 2022 and our documentation is being updated.
 
-To learn about the merger, see [Vipps MobilePay er nå en realitet](https://vipps.no/om-oss/nyheter/vipps-mobilepay-er-n%C3%A5-en-realitet/) (in Norwegian). Excerpt translated to English:
+To learn about the merger, see
+[Vipps MobilePay er nå en realitet](https://vipps.no/om-oss/nyheter/vipps-mobilepay-er-n%C3%A5-en-realitet/)
+(in Norwegian). Excerpt translated to English:
 
 > From today, the new Nordic payment challenger, Vipps MobilePay, is officially in place. - Now we can finally begin the journey towards making Nordic payments even easier, says the now Nordic payments manager, Rune Garborg.
 1.11.2022
 
 For more information about Vipps MobilePay, see [vippsmobilepay.com](https://vippsmobilepay.com/#about).
 
-
 Most MobilePay developer information is still found on the
-[MobilePay developers website](https://developer.mobilepay.dk/), but this will be updated soon.
+[MobilePay developers website](https://developer.mobilepay.dk/),
+but will be moved to this website soon.
 
-If you need help with MobilePay information, see [MobilePay Developer Support](https://developer.mobilepay.dk/docs/support). For help with Vipps, see [Vipps support](contact.md#vipps-support).
+If you need help using the Vipps MobilePay APIs or other technical developer help:
+[Contact us](contact.md).


### PR DESCRIPTION
Better to link to the common contact page, since we also try to direct users to Customer Service, Plugins, etc. there. 